### PR TITLE
Fix prehash crashing on newer NVIDIA drivers

### DIFF
--- a/secp256k1/src/prehash.cu
+++ b/secp256k1/src/prehash.cu
@@ -247,7 +247,7 @@ __global__ void InitPrehash(
 		//  Dump result to global memory -- BIG ENDIAN
 		//====================================================================//
 
-#pragma unroll
+#pragma unroll 1
 		for (int i = 0; i < 4; ++i) store64(&(((uint64_t *)hashes)[(tid + 1) * 4 - i - 1]), h[i]);
 		((uint8_t *)hashes)[tid * 32 + 31] = 0;
 	}


### PR DESCRIPTION
Using any NVIDIA driver that is part of a 5XX release branch (such as any drivers released after and including 510.39.01 for Linux or 511.23 for Windows) will cause the miner to crash with cudaErrorIllegalAddress (700) at the prehash stage. Downgrading to an older driver such as 470.141.03 has been a stop-gap solution to getting the miner running again without this patch.

The issue is coming from this line: https://github.com/mhssamadani/Autolykos2_NV_Miner/blob/4de5cea0952a86d5d287d9788146e0840cb9b61d/secp256k1/src/prehash.cu#L251

Simply signaling to the compiler to disable unrolling for this one loop seems to be enough to make the driver happy with no measurable performance difference as far as I have measured.

Fixes #51 #53 